### PR TITLE
Using a dict as "guess" default value in fit_Murn definition gives unexpected results

### DIFF
--- a/pyqha/eos.py
+++ b/pyqha/eos.py
@@ -113,7 +113,7 @@ def calculate_fitted_points(V,a):
 
 ################################################################################
 
-def fit_Murn(V,E,guess=[0.0,0.0,900/RY_KBAR,1.15],lm_pars={}):
+def fit_Murn(V,E,guess=None,lm_pars={}):
     """
     This is the function for fitting with the Murnaghan EOS as a function of volume only.
 
@@ -124,6 +124,8 @@ def fit_Murn(V,E,guess=[0.0,0.0,900/RY_KBAR,1.15],lm_pars={}):
     Note: volumes must be in a.u.^3 and energies in Rydberg.
     
     """
+    if guess is None:
+        guess = [ 0.0, 0.0, 900/RY_KBAR, 1.15 ]
     # reasonable initial guesses for EOS parameters
     if guess[0]==0.0:
         guess[0] = E[len(E) / 2]

--- a/pyqha/eos.py
+++ b/pyqha/eos.py
@@ -128,9 +128,14 @@ def fit_Murn(V,E,guess=None,lm_pars={}):
         guess = [ 0.0, 0.0, 900/RY_KBAR, 1.15 ]
     # reasonable initial guesses for EOS parameters
     if guess[0]==0.0:
-        guess[0] = E[len(E) / 2]
+        guess[0] = min(E)
+        index = E.index(guess[0])
     if guess[1]==0.0:
-        guess[1] = V[len(V) / 2]
+        try:
+            index
+        except NameError:
+            index = len(V) / 2
+        guess[1] = V[index]
 
     a, pcov = curve_fit(E_MurnV, V, E, p0=guess, **lm_pars)
     


### PR DESCRIPTION
(See https://docs.python.org/3/tutorial/controlflow.html#default-argument-values )

Let's say I have two sets of data, E1, V1 and E2, V2.

First I call fit_Murn(V1,E1). As guess default value was defined as [0.0, 0.0, ...], guess[0] will be 0.0, and guess[1] will be 0.0, so the two "if"s will trigger and will define "reasonable initial guesses for EOS parameters" as the comment says.

But then, in the same script, I call fit_Murn(V2,E2). Now guess[0] is not 0.0, it will keep the value from the last call, E1[len(E1]/2]. Same for guess[1]. So now they won't trigger the "if"s, may have not-so reasonable initial guesses, and the fitting may give OverflowError: math range error

Using None as guess default value, and asigning the dict inside the function fixes this problem.